### PR TITLE
Add rpath support for Mac OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
+set(CMAKE_MACOSX_RPATH ON)
 
 include(CMakeLists_original.txt)


### PR DESCRIPTION
When compiling the dynamic library on Mac OSX, rpath is needed and was missing. This PR aims at fixing that.