### PR TITLE
Add '--with-pic' argument for configure call

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -72,6 +72,8 @@ class LibjpegTurboConan(ConanFile):
             args.append('--with-12bit' if self.options.enable12bit else '--without-12bit')
             args.append('--with-java' if self.options.java else '--without-java')
             args.append('--with-simd' if self.options.SIMD else '--without-simd')
+            if self.options.fPIC:
+                args.append('--with-pic')
 
             if self.settings.os == "Macos":
                 tools.replace_in_file("configure",


### PR DESCRIPTION
During cross compilation for Android I faced with issue:

```
arm-linux-androideabi/bin/ld: error: ~/.conan/data/libjpeg-turbo/1.5.2/bincrafters/stable/package/96ad6b0d2579568c39c1efb465624c8cc6ee99ec/lib/libturbojpeg.a(libturbojpeg_la-jerror.o): requires unsupported dynamic reloc R_ARM_REL32; recompile with -fPIC
arm-linux-androideabi/bin/ld: warning: shared library text segment is not shareable
```

I have checked generated `Makefile` it looked good (I have found `-fPIC` there) 

I have found similar topic here https://github.com/libjpeg-turbo/libjpeg-turbo/issues/155

I didn't wrap code with `self.settings.os == 'Android'` because I think that this options need to be presented for each platform (feel free to criticize)